### PR TITLE
Full rewrite: multi-stage build process, Debian 11 based

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt --no-install-recommends -y install librocksdb6.11 libboost-system1.74.0 
 
 
 #Install sc-web runtime dependencies
-RUN python3 -m pip install --default-timeout=100 future tornado sqlalchemy numpy configparser progress 
+RUN python3 -m pip install --no-cache-dir --default-timeout=100 future tornado sqlalchemy numpy configparser progress 
 
 #Installing python runtime deps for sc-machine
-RUN python3 -m pip install termcolor tornado 
+RUN python3 -m pip install --no-cache-dir termcolor tornado 
 #Derived from debian and not "base" image because any change in base would cache bust the build environment
 FROM debian:bullseye-slim AS buildenv
 #Install build-time deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim as base
 USER root
 
 #runtime dependencies required for building cxx problem-solvers and scripts
-RUN apt update && apt --no-install-recommends -y install python3-pip python3.9 libpython3.9 curl g++ cmake 
+RUN apt update && apt --no-install-recommends -y install python3-pip python3.9 libpython3.9 curl g++ cmake make
 #Libs required in runtime
 RUN apt --no-install-recommends -y install librocksdb6.11 libboost-system1.74.0 libboost-filesystem1.74.0 python3-rocksdb libboost-python1.74.0 libboost-program-options1.74.0 libglib2.0-0 libqt5network5
 

--- a/problem-solver/cxx/CMakeLists.txt
+++ b/problem-solver/cxx/CMakeLists.txt
@@ -1,0 +1,26 @@
+project (wave)
+site_name (www.ostis.net)
+cmake_minimum_required (VERSION 2.6)
+
+set(SC_MACHINE_ROOT "/ostis/sc-machine/")
+set(SCP_MACHINE_ROOT "${CMAKE_SOURCE_DIR}")
+
+set(CMAKE_BUILD_TYPE Debug)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${SC_MACHINE_ROOT}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${SC_MACHINE_ROOT}/bin)
+set( CMAKE_CXX_FLAGS "-std=c++11")
+
+link_directories(${SC_MACHINE_ROOT}/bin)
+
+set(SC_MEMORY_SRC "${SC_MACHINE_ROOT}/sc-memory/")
+
+message(STATUS "CMake generates " ${CMAKE_GENERATOR})
+
+include_directories(${SC_MEMORY_SRC} ${SC_MACHINE_ROOT})
+
+# Example: add_executable(wave wavefindpath.cpp utils.cpp utils.h)
+add_executable(<executable name> <source files names>)
+
+# Example: target_link_libraries(wave sc-core sc-memory)
+target_link_libraries(<executable name> <used libraries names>)

--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,7 @@ OPTIONS:
   --app             Set a custom path to the app directory(By default, it is expected, that inside the app you have all default directories for kb, problem-solver etc)
   --kb              Set a custom path to kb directory
   --solver          Set a custom path to problem-solvers directory
-  --compile -c      Compile and run specified program
+  --compile -c      Compile and run specified program. Usage: --compile <executable name>
   --startflags --sf To set container startup flags(using --all by default). Usage: --startflags "[OSTIS FLAGS]"
 
 OSTIS FLAGS:

--- a/run.sh
+++ b/run.sh
@@ -32,6 +32,7 @@ OPTIONS:
   --app             Set a custom path to the app directory(By default, it is expected, that inside the app you have all default directories for kb, problem-solver etc)
   --kb              Set a custom path to kb directory
   --solver          Set a custom path to problem-solvers directory
+  --compile -c      Compile and run specified program
   --startflags --sf To set container startup flags(using --all by default). Usage: --startflags "[OSTIS FLAGS]"
 
 OSTIS FLAGS:
@@ -44,74 +45,92 @@ OSTIS FLAGS:
 EOM
 }
 
-while [ $# -ne 0 ]
+for (( i=1; i<=$#; i++))
 do
-  case "$1" in
+  case "${!i}" in
     --help | -h)
       help
       exit 0
       ;;
     --port | -p)
-      if [ -z "$2" ]
+      j=$((i+1))
+      if [ -z "${!j}" ]
       then
         echo "Cannot handle empty port value!"
         help
         exit 1
       else
-        PORT_NEW="$2"
+          PORT_NEW="${!j}"
       fi
       ;;
     --port_old)
-      if [ -z "$2" ]
+      j=$((i+1))
+      if [ -z "${!j}" ]
       then
         echo "Cannot handle empty port value!"
         help
         exit 1
       else
-        PORT_OLD="$2"
+        PORT_OLD="${!j}"
       fi
       ;;
     --app)
-      if [ -z "$2" ]
+      j=$((i+1))
+      if [ -z "${!j}" ]
       then
         echo "Cannot handle empty app path value!"
         help
         exit 1
       else
-        APP_PATH="$2"
+        APP_PATH="${!j}"
         KB_PATH="${APP_PATH}/kb"
         PROBLEM_SOLVER_PATH="${APP_PATH}/problem-solver"
       fi
       ;;
     --kb)
-      if [ -z "$2" ]
+      j=$((i+1))
+      if [ -z "${!j}" ]
       then
         echo "Cannot handle empty kb path value!"
         help
         exit 1
       else
-        KB_PATH="$2"
+        KB_PATH="${!j}"
       fi
       ;;
     --solver)
-      if [ -z "$2" ]
+        j=$((i+1))
+        if [ -z "${!j}" ]
       then
         echo "Cannot handle empty problem-solver path value!"
         help
         exit 1
       else
-        PROBLEM_SOLVER_PATH="$2"
+          PROBLEM_SOLVER_PATH="${!j}"
       fi
       ;;
     --startflags | --sf)
-      if [ -z "$2" ]
+      j=$((i+1))
+      if [ -z "${!j}" ]
       then
         echo "Cannot handle empty startup flags!"
         help
         exit 1
       else
-        SCRIPT_FLAGS="$2"
+        SCRIPT_FLAGS="${!j}"
       fi
+      ;;
+    --compile | -c)
+      j=$((i+1))
+      if [ -z "${!j}" ]
+      then
+        echo "No argument given!"
+        help
+        exit 1
+      else
+        SCRIPT_FLAGS="-c ${!j}"
+      fi
+      ;;
     esac
     shift
 done
@@ -127,7 +146,6 @@ docker run -t -i \
   -p ${PORT_NEW}:8090 \
   -p ${PORT_OLD}:8000 \
   ${IMAGE}:${VERSION} \
-  sh ${OSTIS_SCRIPTS_PATH}/ostis ${SCRIPT_FLAGS}
+   ${SCRIPT_FLAGS}
 
 exit
-

--- a/run.sh
+++ b/run.sh
@@ -140,7 +140,7 @@ then
   SCRIPT_FLAGS="--all"
 fi
 
-docker run -t -i \
+docker run -t -i --rm \
   -v ${KB_PATH}:${OSTIS_PATH}/kb \
   -v ${PROBLEM_SOLVER_PATH}:${OSTIS_PATH}/problem-solver \
   -p ${PORT_NEW}:8090 \

--- a/scripts/ostis
+++ b/scripts/ostis
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 make_all()
 {
@@ -20,12 +20,16 @@ sctp()
 
 sc_web()
 {
-  cd /ostis/sc-machine/web/client
-  yarn run webpack-dev
-
   cd /ostis/scripts
-  echo "\n\e[1;32mStarting the old sc-web on http://localhost:8000 and the new on http://localhost:8090...\e[0m\n"
+  echo "\n\e[1;32mStarting the old sc-web on http://localhost:8000\e[0m\n"
   ./run_scweb.sh &
+}
+
+compile()
+{
+  cd /ostis/problem-solver/cxx
+  cmake -B build
+  make -C build
 }
 
 help()
@@ -41,6 +45,7 @@ OPTIONS:
   --build_kb --kb       Rebuild kb
   --sc-web --web        Run sc-web only
   --sctp                Run sctp only
+  --compile -c          Compile and run specified program
 EOM
 }
 
@@ -53,7 +58,6 @@ do
       ;;
     --all | -a)
       build_kb
-      make_all
       sctp
       sc_web
       ;;
@@ -69,6 +73,11 @@ do
     --sctp)
       sctp
       ;;
+    --compile | -c)
+      build_kb
+      compile
+      /ostis/sc-machine/bin/$2
+      ;;
     esac
     shift
 done
@@ -76,4 +85,3 @@ done
 wait
 
 exit
-

--- a/scripts/ostis
+++ b/scripts/ostis
@@ -45,7 +45,7 @@ OPTIONS:
   --build_kb --kb       Rebuild kb
   --sc-web --web        Run sc-web only
   --sctp                Run sctp only
-  --compile -c          Compile and run specified program
+  --compile -c          Compile and run specified program. Usage: --compile <executable name>
 EOM
 }
 


### PR DESCRIPTION
This PR fundamentally changes how dockerized-ostis works, the amount of changes is very big, so this task will actually be taken step-by-step, this is a first PR in probably a series of 3 or 4 PRs.
Fixes #12, #40.
## A brief changelog. 
### From a user's perspective:
1. Reduced image size from 2.85GB uncompressed to 682MB uncompressed, 4x (!!!) decrease. The download size will be even less due to Docker Hub layers compression.
<img width="991" alt="image" src="https://user-images.githubusercontent.com/43214067/146680094-6b094bd9-3391-4f9e-9bdf-44946cd7454a.png">

2. Added support for building sc-memory dependent programs (i.e `wave_find_path_sc_memory`), it will help students complete their course project without installing Linux VMs.
3. The image can be split in 2 tags now: `0.6.0`, the lightweight and robust, and `0.6.0-full` which uses full sc-machine rebuild (for agents development). We still have to decide if the second option is necessary though. As a result, the main image starts way faster now.


### From developer's perspective:
1. Staged build is now used, which again, reduces final image size and improves cache hit
2. Base is changed from Ubuntu 18.04 to Debian 11 (entirely reversible operation, but read on for the reasons)
3. node:alpine is used for building sc-web, simplifies the trickery of installing nodejs
4. Removal of the new UI of sc-machine (weighs 282MB and requires yarn installed. See details for more)
5. Using `ENTRYPOINT` simplifies scripts for running the container, will enable us to write a simple script for Windows in the near future.
6. Deeply optimized cache hits and network loads, while not sacrificing the convenience of container development - you're safe from both recompiling or re-downloading everything after some insignificant change, this is great for CI (implementing it in the near future is my plan).
7. Paradigm shift towards regularly pushing to the Docker Hub registry, so that students will have to build the image if any changes are pushed to `sc-machine` or `sc-web`
8. Using latest dependencies, such as `llvm-13`, `python-3.9`, etc.

## Details
1. Using debian and not Ubuntu: it's a base distro that doesn't make breaking updates often and provides security updates for longer periods of time. I believe it's a better solution for containers that are running on both servers and clients, while still maintaining full compatibility with Ubuntu (it's just a derivative of Debian, after all). We may change it to latest Ubuntu though, it's not a big deal and won't change the rest of the Dockerfile

2. Removing sudo: it makes no sense to add this package if we're using root as USER anyway. I can see that it was made to preserve compatibility with scripts, but see the points below.

3. Not using sc-machine/scripts/install_deps_ubuntu.sh. Several reasons: this script will not exist in future versions of sc-machine, and some of the libraries (mainly python3.6, llvm-7 and qt4) are unnecessary old, which leads to increase in container size. Having latest versions of dependencies helps with security, too. The main reason though is a bit complex: we install build-time dependencies, then clone the repositories, and then install the second part of build-time deps again, if we use the script. If the cache is invalidated for any of the git repos, it would also invalidate the deps installed, resulting in a lot of unnecessary traffic. One of my separate PRs will try to tackle this with automated image rebuilds for Docker Hub, so it won't be a big deal for the students, but it still would've been a major pain for those who rebuild often (CI and developers) 

4. Deleting the python workaround: not only because we're not using the script anymore, but because it actually didn't work (the version of python in the script is 3.6, not 3.5, so we're not replacing anything)

5. Using alpine node image and not installing it to Debian: the nodejs installation scheme used right now is working correctly, but imo it's super sketchy. I would prefer having a separate image with node already configured and set up. Which brings us to...

6. Excluding sc-machine/web/client Web UI. This is entirely a thing for discussion, but based on my personal experience the usecases of it are very limited, AND it requires node and yarn being installed in the final image. If we don't have any serious reasons to have it alongside sc-web, it will be great, because then we don't need node as a runtime dependency. If we do need it, we can create a separate container with it and provide docker-compose.yml to use it with our ostis instance. We could further split sc-machine and sc-web into separate containers, but it seems unnecessary to me (Python is a runtime dependency in both cases). We can also revert all changes on this, but it is a significant contribution into reducing image size.

7. Using ENTRYPOINT simplifies ./run.sh logic (passing arguments to `scripts/ostis` script) and allows us to implement a simple alternative for uhm, poor Windows users.

## Interlude:
qtbase5-dev IS HEAVY, not by itself, but by the amount of dependencies it installs. Wayland, xorg packets, mesa, xdg, qt5, GTK3, a whole whackload of GUI packets, it is completely irrelevant for a CLI app! I believe it installed more packets than I have on my personal server :D. Obviously this is bad, especially considering that we only actually need QtNetworking for sctp-server (which still sums up to 79MB without -dev packages. What the hell is wrong with Qt...). And I was shocked when I realized we ACTUALLY REBUILD sc-machine every time we launch the container. Which means I couldn't get rid of any of those super heavy dependencies. To make sc-machine portable, we have to get rid of Qt Base dependency in the sc-machine itself, but I understand that we're in a midst of a giant rewrite, so I won't wait for it to get done. It is surely a complex problem, and I have a proposal:

The idea: who is the main target audience for this image? I envision it as a testing environment for knowledge base changes and a quick way to get started with SC-machine for students, and then *maybe* an environment for developing agents in an isolated way. So, the first and foremost, this image should be quick to download, install, setup and run. Secondly, it should be able to run sc-web and show the knowledge base changes (which it already does), and it also should help students complete the first part of the 3rd semester cource project (so, being able to compile and run apps like `ostis-apps/wave_find_path_sc_memory`). If this concept aligns with what you think this container should be, let's continue:

## Changes related to sc-machine
1. Getting rid of sc-machine rebuilds. Pros: this will allow us to get rid of all build-time dependencies of sc-machine, reducing the image size by a lot. The image will start faster, too. Cons: building agents will become impossible, because it requires sc-machine to be rebuilt. Possible solution: to have two tags with full image (with all the build environment).

2. Adding support for running sc-memory programs. This will allow students to use the image to complete the first part of the 3rd semester course project, which I see as a HUGE usecase.


Commentary on other design decisions:
1. I've decided to create 2 tags, `0.6.0` and *maybe* `0.6.0-full`, as described above, the full image contains all the build dependencies, so it will weight just as much as the old one, but it will enable people to build agents on C++, just like before. I don't think we need that, but maybe I'm missing something.

2. Duplicates of packages on several lines (i.e installing `librocksdb` as both runtime and build-time dependency). It doesn't actually downloads anything again, but ensures the integrity of the build process between different containers, especially if runtime dependencies will change at any given moment.

3. Making "buildenv" inherit from "base" image was my first idea, and it WAS A HORRIBLE IDEA, it pissed me off so much when I was testing the new Dockerfile... So, when I lost enough time cache-busting the "buildenv", I've made "buildenv" and base to build independently, because every time I changed anything in "base" image, everything in the "buildenv" had to be redownloaded. We have to download g++ and python twice because of this change, but the traffic difference only kicks in when you're building, not pulling the image, and in my opinion the costs of installing the ton of build-dependencies outweighs the double download traffic loss, which also holds true for the CI usecase.

4. `rm -rf /var/lib/apt/lists/*` is not used because apparently, official Ubuntu and Debian images do that for you anyway. https://github.com/moby/moby/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105

Prospects of this change:
1. If the change fits well, we could tell all the teachers to mention OSTIS installation with Docker as an option (probably the main option, for most people).
2. This image could be used in ims.ostis.kb and other KB projects to check the integrity of it (i.e if any change triggers a build failure). So, it basically allows us to CI the knowledge base, sounds cool!
3. Basically having a Docker image as a first-class citizen means we support any OS on almost any architecture. macOS, Windows, Linux, arm64, x86_64, it doesn't really matter if we're using a container, so I believe that development shouldn't stop here. 

Future plans:
1. Update docs, with a clear example on how to develop course project apps in Docker environment (probably using VSCode and container-native extensions for it)
2. Add CI (GitHub Action) to rebuild this image on every change in this repo and push it to Docker Hub. Maybe also rebuilding on sc-machine\sc-web\ims.ostis.kb pushes of the relevant branches
3. Adding CI to ims.ostis.kb or graph theory project to check the integrity of the KB

## Caveats
1. I've found that 0.6.0 from `ShunkevichDV/sc-machine` currently doesn't have patches necessary for arm64 under macOS (ostis-dev/sc-machine doesn't have it either in 0.6.0 branch, see https://github.com/ostis-dev/sc-machine/issues/419), so the arm64 image built by Moby `BuildKit` will not work on M1 Macs, resulting in `Bus error` and segfaults. It has to be fixed on the `sc-machine` side though.


